### PR TITLE
Refactor/#26

### DIFF
--- a/Assets/Scripts/App/ChartManager.cs
+++ b/Assets/Scripts/App/ChartManager.cs
@@ -75,6 +75,8 @@ namespace SCOdyssey.Game
 
         private Action<JudgeType, NoteController> judgeEffectAction;
 
+        private double _judgmentOffsetSec;
+
 
         void Awake()
         {
@@ -88,7 +90,10 @@ namespace SCOdyssey.Game
             currentBarNumber = 0;
 
             if (ServiceLocator.TryGet<ISettingsManager>(out var settingsManager))
+            {
                 m_showPerfect = settingsManager.Current.showPerfect;
+                _judgmentOffsetSec = settingsManager.Current.judgmentOffset * 0.003;
+            }
 
             // TODO: 4/4박자가 아닐경우의 barDuration 계산 (BPM 기반)
             barDuration = 60f / chartData.bpm * 4f; // 4/4박자 기준
@@ -546,12 +551,8 @@ namespace SCOdyssey.Game
             NoteController targetNote = queue.Peek();
             if (targetNote.noteData.noteType != NoteType.Normal && targetNote.noteData.noteType != NoteType.HoldStart) return;
 
-            double offsetSec = 0;
-            if (ServiceLocator.TryGet<ISettingsManager>(out var sm))
-                offsetSec = sm.Current.judgmentOffset * 0.003;
-
             // 판정 타이밍 오프셋 적용: 윈도우 중심을 noteTime + offsetSec으로 이동
-            double timeDiff = Math.Abs(inputGameTime - targetNote.noteData.time - offsetSec);
+            double timeDiff = Math.Abs(inputGameTime - targetNote.noteData.time - _judgmentOffsetSec);
 
             if (timeDiff > JUDGE_UMM)   // 판정 범위 밖
             {
@@ -599,11 +600,7 @@ namespace SCOdyssey.Game
             if (targetNote.noteData.noteType != NoteType.Holding &&
                 targetNote.noteData.noteType != NoteType.HoldEnd) return;
 
-            double offsetSec = 0;
-            if (ServiceLocator.TryGet<ISettingsManager>(out var sm))
-                offsetSec = sm.Current.judgmentOffset * 0.003;
-
-            double timeDiff = Math.Abs(gameManager.GetCurrentTime() - targetNote.noteData.time - offsetSec);
+            double timeDiff = Math.Abs(gameManager.GetCurrentTime() - targetNote.noteData.time - _judgmentOffsetSec);
 
             if (timeDiff < JUDGE_PERFECT)
             {
@@ -628,11 +625,7 @@ namespace SCOdyssey.Game
             NoteController targetNote = queue.Peek();
             if (targetNote.noteData.noteType != NoteType.HoldRelease) return; // 릴리즈 판정 노트가 없으면 무시
 
-            double offsetSec = 0;
-            if (ServiceLocator.TryGet<ISettingsManager>(out var sm2))
-                offsetSec = sm2.Current.judgmentOffset * 0.003;
-
-            double timeDiff = Math.Abs(inputGameTime - targetNote.noteData.time - offsetSec);
+            double timeDiff = Math.Abs(inputGameTime - targetNote.noteData.time - _judgmentOffsetSec);
 
             if (timeDiff > JUDGE_UMM)   // 판정 범위 밖
             {

--- a/Assets/Scripts/App/ChartManager.cs
+++ b/Assets/Scripts/App/ChartManager.cs
@@ -560,15 +560,7 @@ namespace SCOdyssey.Game
                 return;
             }
 
-            JudgeType result = JudgeType.Perfect;
-
-            if (timeDiff <= JUDGE_PERFECT) result = JudgeType.Perfect;
-            else if (timeDiff <= JUDGE_MASTER) result = JudgeType.Master;
-            else if (timeDiff <= JUDGE_IDEAL) result = JudgeType.Ideal;
-            else if (timeDiff <= JUDGE_KIND) result = JudgeType.Kind;
-            else if (timeDiff <= JUDGE_UMM) result = JudgeType.Umm;
-
-            ApplyJudgment(targetNote, listIndex, result);
+            ApplyJudgment(targetNote, listIndex, GetJudgeType(timeDiff));
 
         }
 
@@ -633,15 +625,16 @@ namespace SCOdyssey.Game
                 return;
             }
 
-            JudgeType result = JudgeType.Perfect;
+            ApplyJudgment(targetNote, listIndex, GetJudgeType(timeDiff));
+        }
 
-            if (timeDiff <= JUDGE_PERFECT) result = JudgeType.Perfect;
-            else if (timeDiff <= JUDGE_MASTER) result = JudgeType.Master;
-            else if (timeDiff <= JUDGE_IDEAL) result = JudgeType.Ideal;
-            else if (timeDiff <= JUDGE_KIND) result = JudgeType.Kind;
-            else if (timeDiff <= JUDGE_UMM) result = JudgeType.Umm;
-
-            ApplyJudgment(targetNote, listIndex, result);
+        private static JudgeType GetJudgeType(double timeDiff)
+        {
+            if (timeDiff <= JUDGE_PERFECT) return JudgeType.Perfect;
+            if (timeDiff <= JUDGE_MASTER)  return JudgeType.Master;
+            if (timeDiff <= JUDGE_IDEAL)   return JudgeType.Ideal;
+            if (timeDiff <= JUDGE_KIND)    return JudgeType.Kind;
+            return JudgeType.Umm;
         }
 
 

--- a/Assets/Scripts/App/ChartManager.cs
+++ b/Assets/Scripts/App/ChartManager.cs
@@ -77,6 +77,10 @@ namespace SCOdyssey.Game
 
         private double _judgmentOffsetSec;
 
+        private readonly HashSet<int> _nextGroupsBuffer = new HashSet<int>();
+        private readonly Dictionary<int, bool> _nextGroupDirBuffer = new Dictionary<int, bool>();
+        private readonly List<int> _groupsToRemoveBuffer = new List<int>();
+
 
         void Awake()
         {
@@ -192,27 +196,27 @@ namespace SCOdyssey.Game
                 return;
             }
 
-            HashSet<int> nextGroups = new HashSet<int>();
-            Dictionary<int, bool> nextGroupDirection = new Dictionary<int, bool>();
+            _nextGroupsBuffer.Clear();
+            _nextGroupDirBuffer.Clear();
 
             foreach (var lane in nextBarLanes)
             {
                 int groupID = GetTrackGroupID(lane.line - 1);
-                nextGroups.Add(groupID);
-                nextGroupDirection[groupID] = lane.isLTR;
+                _nextGroupsBuffer.Add(groupID);
+                _nextGroupDirBuffer[groupID] = lane.isLTR;
             }
 
-            List<int> groupsToRemove = new List<int>(); // 제거할 그룹 ID 목록
+            _groupsToRemoveBuffer.Clear();
 
             foreach (var kvp in activeTimelines)
             {
                 int groupID = kvp.Key;
                 TimelineController timeline = kvp.Value;
 
-                if (nextGroups.Contains(groupID) && timeline.isLTR != nextGroupDirection[groupID])
+                if (_nextGroupsBuffer.Contains(groupID) && timeline.isLTR != _nextGroupDirBuffer[groupID])
                 {
                     // 재활용
-                    bool isLTR = nextGroupDirection[groupID];
+                    bool isLTR = _nextGroupDirBuffer[groupID];
                     float startX, endX;
                     GetTimelinePositions(isLTR, out startX, out endX);
 
@@ -227,11 +231,11 @@ namespace SCOdyssey.Game
                 }
                 else
                 {
-                    groupsToRemove.Add(groupID);    // 여기서 바로 제거하면 컬렉션 변경 오류 발생
+                    _groupsToRemoveBuffer.Add(groupID);
                 }
             }
 
-            foreach (int id in groupsToRemove) activeTimelines.Remove(id);  // 반복문 종료 후 제거
+            foreach (int id in _groupsToRemoveBuffer) activeTimelines.Remove(id);
 
             ActivateTimelines();
             ActivateGhostNotes();
@@ -306,26 +310,26 @@ namespace SCOdyssey.Game
 
         private void PreloadTimelines()
         {
-            HashSet<int> nextGroups = new HashSet<int>();
-            Dictionary<int, bool> nextGroupDirection = new Dictionary<int, bool>();
+            _nextGroupsBuffer.Clear();
+            _nextGroupDirBuffer.Clear();
 
             foreach (var laneData in nextBarLanes)
             {
                 int groupID = GetTrackGroupID(laneData.line - 1);
-                if (!nextGroups.Contains(groupID))
+                if (!_nextGroupsBuffer.Contains(groupID))
                 {
-                    nextGroups.Add(groupID);
-                    nextGroupDirection[groupID] = laneData.isLTR;
+                    _nextGroupsBuffer.Add(groupID);
+                    _nextGroupDirBuffer[groupID] = laneData.isLTR;
                 }
             }
 
             double nextStartTime = currentBarNumber * barDuration;
 
-            foreach (int groupID in nextGroups)
+            foreach (int groupID in _nextGroupsBuffer)
             {
                 bool isReused = false;
                 if (activeTimelines.TryGetValue(groupID, out var existing) &&
-                    existing.isLTR != nextGroupDirection[groupID])
+                    existing.isLTR != _nextGroupDirBuffer[groupID])
                 {
                     isReused = true;
                 }
@@ -336,7 +340,7 @@ namespace SCOdyssey.Game
                     timeline.transform.SetParent(timelineParent, false);
                     timeline.transform.position = timelineTransforms[groupID].position;
 
-                    bool isLTR = nextGroupDirection[groupID];
+                    bool isLTR = _nextGroupDirBuffer[groupID];
                     float startX, endX;
                     GetTimelinePositions(isLTR, out startX, out endX);
 
@@ -352,7 +356,7 @@ namespace SCOdyssey.Game
                     preloadedTimelines.Add(groupID, timeline);
                 }
 
-                int uiIndex = (groupID * 2) + (nextGroupDirection[groupID] ? 0 : 1);
+                int uiIndex = (groupID * 2) + (_nextGroupDirBuffer[groupID] ? 0 : 1);
                 ActivateCountdown(uiIndex, nextStartTime);
             }
 

--- a/Assets/Scripts/App/ChartManager.cs
+++ b/Assets/Scripts/App/ChartManager.cs
@@ -324,10 +324,10 @@ namespace SCOdyssey.Game
             foreach (int groupID in nextGroups)
             {
                 bool isReused = false;
-                if (activeTimelines.ContainsKey(groupID))   // 재사용의 경우
+                if (activeTimelines.TryGetValue(groupID, out var existing) &&
+                    existing.isLTR != nextGroupDirection[groupID])
                 {
-                    if (activeTimelines[groupID].isLTR != nextGroupDirection[groupID])
-                        isReused = true;
+                    isReused = true;
                 }
 
                 if (!isReused)  // 새 판정선 생성
@@ -365,11 +365,7 @@ namespace SCOdyssey.Game
                 int groupID = kvp.Key;
                 TimelineController timeline = kvp.Value;
                 
-                if (!activeTimelines.ContainsKey(groupID))
-                {
-                    activeTimelines.Add(groupID, timeline);
-                }
-                else
+                if (!activeTimelines.TryAdd(groupID, timeline))
                 {
                     Debug.LogWarning("Timeline 승격 중복 발생: 그룹 " + groupID);
                     ReturnTimelineToPool(timeline.gameObject);
@@ -516,9 +512,9 @@ namespace SCOdyssey.Game
                     if (note.noteData.noteType == NoteType.HoldStart)
                     {
                         int groupID = GetTrackGroupID(i);
-                        if (activeTimelines.ContainsKey(groupID))
+                        if (activeTimelines.TryGetValue(groupID, out var timeline))
                         {
-                            note.TrackTimeline(activeTimelines[groupID]);
+                            note.TrackTimeline(timeline);
                         }
                     }
 

--- a/Assets/Scripts/App/ChartManager.cs
+++ b/Assets/Scripts/App/ChartManager.cs
@@ -61,16 +61,19 @@ namespace SCOdyssey.Game
         private double currentBarEndTime = 0f; // 현재 마디의 종료 시간
         private double barDuration = 0f; // 마디별 진행시간 = 악보상의 박자표(4/4) * 4 * 60 / BPM
 
-        private Queue<NoteController>[] activeNotes = new Queue<NoteController>[LANE_COUNT]; // 각 레인별 활성화된 노트 큐
-        private Queue<NoteController>[] ghostNotes = new Queue<NoteController>[LANE_COUNT]; // 각 레인별 고스트 노트 큐
-
-        private bool[] isLaneHolding = { false, false, false, false }; // 각 레인별 롱노트 홀딩 상태 추적
-        private double?[] bufferedInput = new double?[LANE_COUNT]; // 마디 전환 직전 선입력 버퍼 (index: laneIndex - 1)
-        
         public TextMeshProUGUI[] countdownTexts = new TextMeshProUGUI[LANE_COUNT];
 
-        private double[] countdownTargetTimes = new double[LANE_COUNT];
-        private bool[] isCountdownActive = new bool[LANE_COUNT];
+        private LaneState[] _lanes;
+
+        private class LaneState
+        {
+            public readonly Queue<NoteController> activeNotes = new Queue<NoteController>();
+            public readonly Queue<NoteController> ghostNotes = new Queue<NoteController>();
+            public bool isHolding;
+            public double? bufferedInput;
+            public double countdownTargetTime;
+            public bool isCountdownActive;
+        }
 
 
         private Action<JudgeType, NoteController> judgeEffectAction;
@@ -84,7 +87,9 @@ namespace SCOdyssey.Game
 
         void Awake()
         {
-            //chartData = GameManager.chartData;
+            _lanes = new LaneState[LANE_COUNT];
+            for (int i = 0; i < LANE_COUNT; i++)
+                _lanes[i] = new LaneState();
         }
 
         public void Init(ChartData chartData, IGameManager gameManager)
@@ -105,11 +110,13 @@ namespace SCOdyssey.Game
 
             for (int i = 0; i < LANE_COUNT; i++)
             {
-                activeNotes[i] = new Queue<NoteController>();
-                ghostNotes[i] = new Queue<NoteController>();
+                _lanes[i].activeNotes.Clear();
+                _lanes[i].ghostNotes.Clear();
+                _lanes[i].isHolding = false;
+                _lanes[i].bufferedInput = null;
+                _lanes[i].isCountdownActive = false;
 
                 countdownTexts[i].gameObject.SetActive(false);
-                isCountdownActive[i] = false;
                 countdownTexts[i].text = "";
             }
 
@@ -132,7 +139,7 @@ namespace SCOdyssey.Game
             for (int i = 0; i < LANE_COUNT; i++)
             {
                 CheckMissedNotes(i, currentTime);
-                if (isLaneHolding[i]) CheckHoldingBody(i);
+                if (_lanes[i].isHolding) CheckHoldingBody(i);
             }
             
             UpdateCountdowns();
@@ -149,8 +156,8 @@ namespace SCOdyssey.Game
 
             for (int i = 0; i < LANE_COUNT; i++)
             {
-                if (activeNotes[i].Count > 0) return;
-                if (ghostNotes[i].Count > 0) return;
+                if (_lanes[i].activeNotes.Count > 0) return;
+                if (_lanes[i].ghostNotes.Count > 0) return;
             }
 
             // 음악이 아직 재생 중이면 대기
@@ -261,14 +268,14 @@ namespace SCOdyssey.Game
 
             for (int i = 0; i < LANE_COUNT; i++)
             {
-                if (!isCountdownActive[i]) continue;
+                if (!_lanes[i].isCountdownActive) continue;
 
-                double timeDiff = countdownTargetTimes[i] - currentTime;
+                double timeDiff = _lanes[i].countdownTargetTime - currentTime;
 
                 if (timeDiff <= 0)
                 {
                     countdownTexts[i].gameObject.SetActive(false);
-                    isCountdownActive[i] = false;
+                    _lanes[i].isCountdownActive = false;
                     continue;
                 }
 
@@ -293,13 +300,13 @@ namespace SCOdyssey.Game
         
         private void ActivateCountdown(int index, double targetTime)
         {
-            if (isCountdownActive[index] && Math.Abs(countdownTargetTimes[index] - targetTime) < 0.01d) return;
+            if (_lanes[index].isCountdownActive && Math.Abs(_lanes[index].countdownTargetTime - targetTime) < 0.01d) return;
 
             countdownTexts[index].gameObject.SetActive(true);
             countdownTexts[index].text = "";
 
-            countdownTargetTimes[index] = targetTime;
-            isCountdownActive[index] = true;
+            _lanes[index].countdownTargetTime = targetTime;
+            _lanes[index].isCountdownActive = true;
         }
 
 
@@ -496,19 +503,18 @@ namespace SCOdyssey.Game
                         noteController.SetState(NoteState.Ghost);
                     }
 
-                    ghostNotes[lane.line - 1].Enqueue(noteController);
+                    _lanes[lane.line - 1].ghostNotes.Enqueue(noteController);
                 }
             }
         }
 
         private void ActivateGhostNotes()
         {
-            if (ghostNotes == null) return;
             for (int i = 0; i < LANE_COUNT; i++)
             {
-                while (ghostNotes[i].Count > 0)
+                while (_lanes[i].ghostNotes.Count > 0)
                 {
-                    NoteController note = ghostNotes[i].Dequeue();
+                    NoteController note = _lanes[i].ghostNotes.Dequeue();
                     note.SetState(NoteState.Active);
 
                     // HoldStart만 타임라인 추적: 홀드바 fill 애니메이션에 사용
@@ -522,8 +528,8 @@ namespace SCOdyssey.Game
                         }
                     }
 
-                    activeNotes[i].Enqueue(note);
-                    FlushBufferedInput(i); // 선입력이 있으면 즉시 재판정
+                    _lanes[i].activeNotes.Enqueue(note);
+                    FlushBufferedInput(i);
                 }
             }
         }
@@ -535,16 +541,16 @@ namespace SCOdyssey.Game
         public void TryJudgeInput(int laneIndex, double inputGameTime)
         {
             int listIndex = laneIndex - 1;  // 인덱스 보정
-            isLaneHolding[listIndex] = true;
+            _lanes[listIndex].isHolding = true;
 
             // 판정 결과와 무관하게 입력 이벤트를 먼저 발화 (캐릭터 Y 이동 담당)
             gameManager.OnLaneInput(GetNotePosition(listIndex), GetTrackGroupID(listIndex));
 
-            var queue = activeNotes[listIndex];
+            var queue = _lanes[listIndex].activeNotes;
             if (queue.Count == 0)
             {
                 // 마디 전환 직전 선입력: 노트가 활성화되면 FlushBufferedInput에서 재판정
-                bufferedInput[listIndex] = inputGameTime;
+                _lanes[listIndex].bufferedInput = inputGameTime;
                 return;
             }
 
@@ -570,19 +576,19 @@ namespace SCOdyssey.Game
         /// </summary>
         private void FlushBufferedInput(int listIndex)
         {
-            if (!bufferedInput[listIndex].HasValue) return;
+            if (!_lanes[listIndex].bufferedInput.HasValue) return;
 
-            double inputTime = bufferedInput[listIndex].Value;
-            bufferedInput[listIndex] = null;
+            double inputTime = _lanes[listIndex].bufferedInput.Value;
+            _lanes[listIndex].bufferedInput = null;
 
-            if (!isLaneHolding[listIndex]) return; // 이미 손을 뗀 경우 폐기
+            if (!_lanes[listIndex].isHolding) return; // 이미 손을 뗀 경우 폐기
 
             TryJudgeInput(listIndex + 1, inputTime);
         }
 
         private void CheckHoldingBody(int listIndex)
         {
-            var queue = activeNotes[listIndex];
+            var queue = _lanes[listIndex].activeNotes;
             if (queue.Count == 0) return;
 
             //Debug.Log($"Lane {listIndex+1} Holding now, currentTime: {currentTime}");
@@ -606,12 +612,12 @@ namespace SCOdyssey.Game
         public void TryJudgeRelease(int laneIndex, double inputGameTime)
         {
             int listIndex = laneIndex - 1;
-            isLaneHolding[listIndex] = false;
+            _lanes[listIndex].isHolding = false;
 
             // 키 릴리즈는 판정 성공 여부와 무관하게 홀드 상태 해제 신호로 사용
             gameManager.OnHoldRelease(GetNotePosition(listIndex), GetTrackGroupID(listIndex));
 
-            var queue = activeNotes[listIndex];
+            var queue = _lanes[listIndex].activeNotes;
             if (queue.Count == 0) return;
 
             NoteController targetNote = queue.Peek();
@@ -647,7 +653,7 @@ namespace SCOdyssey.Game
         private void ApplyJudgment(NoteController targetNote, int listIndex, JudgeType type)
         {
             //Debug.Log($"Note Judged: {type}");
-            activeNotes[listIndex].Dequeue();
+            _lanes[listIndex].activeNotes.Dequeue();
             targetNote.OnHit();
 
             NotePosition pos = GetNotePosition(listIndex);
@@ -674,13 +680,13 @@ namespace SCOdyssey.Game
         
         private void CheckMissedNotes(int listIndex, double currentTime)
         {
-            if (activeNotes[listIndex].Count == 0) return;
+            if (_lanes[listIndex].activeNotes.Count == 0) return;
 
-            NoteController targetNote = activeNotes[listIndex].Peek();
+            NoteController targetNote = _lanes[listIndex].activeNotes.Peek();
 
             if (currentTime > targetNote.noteData.time + JUDGE_UMM)
             {
-                activeNotes[listIndex].Dequeue();
+                _lanes[listIndex].activeNotes.Dequeue();
                 targetNote.OnMiss();
 
                 gameManager.OnNoteMissed();


### PR DESCRIPTION
## **구현 목표**

`ChartManager.cs` 핫패스 성능 개선 및 코드 품질 리팩터링.
프레임 드랍 방지와 유지보수성 향상을 목적으로 합니다.

---

## **변경 사항**

### 성능 개선

- **`judgmentOffset` 캐싱** — `TryJudgeInput`, `CheckHoldingBody`, `TryJudgeRelease`에서 매 호출마다 실행하던 `ServiceLocator.TryGet<ISettingsManager>()`를 `Init()` 시점 1회 캐싱으로 대체
- **마디 전환 임시 컬렉션 재사용** — `StartCurrentBar`, `PreloadTimelines`에서 매 마디(~2초)마다 생성하던 `HashSet`, `Dictionary`, `List`를 멤버 버퍼 필드로 선언하고 `Clear()` 후 재사용

### 리팩터링

- **`LaneState` 클래스 통합** — `activeNotes`, `ghostNotes`, `isLaneHolding`, `bufferedInput`, `countdownTargetTimes`, `isCountdownActive` 6개 병렬 배열을 `LaneState` 클래스로 묶어 레인 단위 상태를 단일 지점에서 관리
- **판정 로직 중복 제거** — `TryJudgeInput`, `TryJudgeRelease`의 `timeDiff → JudgeType` 변환 블록을 `GetJudgeType()` 헬퍼로 추출
- **Dictionary double lookup 개선** — `PreloadTimelines`, `ActivateTimelines`, `ActivateGhostNotes`의 `ContainsKey` + 인덱서 이중 탐색을 `TryGetValue` / `TryAdd`로 교체

close #26 