### PR TITLE
refactor: UI 스택을 레지스트리/인스턴스 분리구조로 재설계 (#44)

### DIFF
--- a/Assets/Scripts/App/Interfaces/IUIManager.cs
+++ b/Assets/Scripts/App/Interfaces/IUIManager.cs
@@ -4,9 +4,18 @@ using UnityEngine;
 
 namespace SCOdyssey.App
 {
+    // UI 진입 방식
+    // Push    : 아래 UI를 숨기고 새 UI를 최상단에 추가 (기본값)
+    // Overlay : 아래 UI를 보이는 채로 두고 위에 겹쳐 추가 (팝업)
+    // Replace : 현재 최상단을 같은 깊이로 교체 (탭 전환 등, 뒤로가기 Depth를 늘리지 않음)
+    public enum PushMode { Push, Overlay, Replace }
+
     public interface IUIManager
     {
-        public T ShowUI<T>(string name = null, Transform parent = null) where T : BaseUI;
+        public T ShowUI<T>(PushMode mode = PushMode.Push) where T : BaseUI;
         public void CloseUI(BaseUI ui);
+        
+        // 입력 라우팅용: 현재 최상단 UI 반환 (없으면 null)
+        public BaseUI PeekUI();
     }
 }

--- a/Assets/Scripts/App/UIManager.cs
+++ b/Assets/Scripts/App/UIManager.cs
@@ -10,25 +10,14 @@ namespace SCOdyssey.App
 {
     public class UIManager : IUIManager
     {
-        private struct Entry
-        {
-            public string key;
-            public PushMode mode;
-            public Entry(string key, PushMode mode) { this.key = key; this.mode = mode; }
-        }
-
         // 표시되는 UI Canvas의 기준 sortingOrder. 게임 씬의 오브젝트 레이어보다 높아야 함.
         private const int BaseSortingOrder = 100;
 
         // UI 기록과 인스턴스 소유를 분리한다.
-        // _history : 기록만 보관 (UI 키 + 진입 모드). 뒤로가기 경로를 기억한다.
+        // _stack     : 네비게이션 기록하는 자료구조
         // _instances : 실제 UI 인스턴스. 지연 생성 후 캐싱하여 재사용한다 (Destroy 하지 않음).
-        private readonly Stack<Entry> _history = new Stack<Entry>();
+        private readonly UIStack _stack = new UIStack();
         private readonly Dictionary<string, BaseUI> _instances = new Dictionary<string, BaseUI>();
-
-        // 씬 바닥 경계: 이 Depth 하위의 UI는 현재 씬에서 사용하지 않는다.
-        // MainScene에서는 0(로비 스택 전체 소유), 그 외 씬에서는 진입 시점의 스택 크기로 고정한다.
-        private int _floor = 0;
 
         public GameObject Root
         {
@@ -56,7 +45,7 @@ namespace SCOdyssey.App
             RefreshCamera();
 
             // MainScene: 로비 스택 전체를 소유 / 그 외 씬: 진입 시점 스택을 바닥 경계로 고정해 로비 UI를 숨긴다.
-            _floor = scene.name == "MainScene" ? 0 : _history.Count;
+            _stack.SetFloor(scene.name == "MainScene" ? 0 : _stack.Count);
             RefreshVisibility();
         }
 
@@ -119,19 +108,13 @@ namespace SCOdyssey.App
             string key = typeof(T).Name;
 
             // 이미 최상단인 UI를 다시 요청하면 그대로 반환 (중복 push 방지)
-            if (_history.Count > 0 && _history.Peek().key == key)
+            if (_stack.TopKey == key)
             {
                 return (T)GetUI(key);
             }
 
             BaseUI ui = GetUI(key);
-
-            // Replace: 현재 최상단 기록을 같은 Depth로 교체
-            if (mode == PushMode.Replace && _history.Count > 0)
-            {
-                _history.Pop();
-            }
-            _history.Push(new Entry(key, mode));
+            _stack.Push(key, mode);
 
             RefreshVisibility();
             return (T)ui;
@@ -141,14 +124,15 @@ namespace SCOdyssey.App
         // 최당산의 UI만 입력을 받도록 PeekUI()를 통해 라우팅한다. (UIManager는 입력 이벤트를 직접 처리하지 않음)
         public BaseUI PeekUI()
         {
-            if (_history.Count == 0) return null;
-            return _instances.TryGetValue(_history.Peek().key, out var ui) ? ui : null;
+            string key = _stack.TopKey;
+            if (key == null) return null;
+            return _instances.TryGetValue(key, out var ui) ? ui : null;
         }
 
         // UI 스택의 가장 위에 있는 UI 닫기 (캐시는 유지, Destroy 하지 않음)
         public void CloseUI(BaseUI closeUi)
         {
-            if (_history.Count == 0)
+            if (_stack.Count == 0)
             {
                 return;
             }
@@ -158,23 +142,20 @@ namespace SCOdyssey.App
                 return;
             }
 
-            _history.Pop();
+            _stack.Pop();
             RefreshVisibility();
         }
 
-        // 표시 집합 계산 → 활성/비활성 토글 + sortingOrder 재할당을 위해 구분한다.
-        // 표시 집합 구분 = 최상단부터 아래로, Overlay인 동안 그 아래까지 포함하고,
-        //                 Overlay가 아닌 첫 UI를 포함한 뒤 정지. 단, 바닥경계(_floor) 밑으로는 내려가지 않음.
+        // 표시할 UI 키를 UIStack에서 받아, 활성/비활성 토글 + sortingOrder를 재할당한다.
+        // 표시 집합 계산 = 최상단부터 Overlay 규칙 + 바닥경계는 UIStack.GetVisibleKeys가 담당
         private void RefreshVisibility()
         {
-            Entry[] arr = _history.ToArray();           // arr[0] = 최상단
-            int aboveFloor = arr.Length - _floor;       // 바닥경계 위(현재 씬 소유) 기록 수
+            IReadOnlyList<string> visibleKeys = _stack.GetVisibleKeys();   // 0번이 최상단
 
-            var visible = new List<BaseUI>();           // 0번이 최상단
-            for (int i = 0; i < arr.Length && i < aboveFloor; i++)
+            var visible = new List<BaseUI>(visibleKeys.Count);
+            foreach (var key in visibleKeys)
             {
-                visible.Add(GetUI(arr[i].key));
-                if (arr[i].mode != PushMode.Overlay) break; // base 도달 ㅅㅣ 정지
+                visible.Add(GetUI(key));
             }
 
             // 표시 집합 외의 모든 캐시는 비활성화

--- a/Assets/Scripts/App/UIManager.cs
+++ b/Assets/Scripts/App/UIManager.cs
@@ -10,8 +10,26 @@ namespace SCOdyssey.App
 {
     public class UIManager : IUIManager
     {
-        private int order = -20;    // sorting order에 사용할 변수
-        private Stack<BaseUI> uiStack = new Stack<BaseUI>();
+        private struct Entry
+        {
+            public string key;
+            public PushMode mode;
+            public Entry(string key, PushMode mode) { this.key = key; this.mode = mode; }
+        }
+
+        // 표시되는 UI Canvas의 기준 sortingOrder. 게임 씬의 오브젝트 레이어보다 높아야 함.
+        private const int BaseSortingOrder = 100;
+
+        // UI 기록과 인스턴스 소유를 분리한다.
+        // _history : 기록만 보관 (UI 키 + 진입 모드). 뒤로가기 경로를 기억한다.
+        // _instances : 실제 UI 인스턴스. 지연 생성 후 캐싱하여 재사용한다 (Destroy 하지 않음).
+        private readonly Stack<Entry> _history = new Stack<Entry>();
+        private readonly Dictionary<string, BaseUI> _instances = new Dictionary<string, BaseUI>();
+
+        // 씬 바닥 경계: 이 Depth 하위의 UI는 현재 씬에서 사용하지 않는다.
+        // MainScene에서는 0(로비 스택 전체 소유), 그 외 씬에서는 진입 시점의 스택 크기로 고정한다.
+        private int _floor = 0;
+
         public GameObject Root
         {
             get
@@ -26,6 +44,7 @@ namespace SCOdyssey.App
                 return root;
             }
         }
+
         public void Init()
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
@@ -35,10 +54,10 @@ namespace SCOdyssey.App
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             RefreshCamera();
-            // MainScene: 스택에 보존된 UI를 다시 표시 / 그 외 씬: UI 숨김 (스택은 유지)
-            bool isMainScene = scene.name == "MainScene";
-            foreach (Transform child in Root.transform)
-                child.gameObject.SetActive(isMainScene);
+
+            // MainScene: 로비 스택 전체를 소유 / 그 외 씬: 진입 시점 스택을 바닥 경계로 고정해 로비 UI를 숨긴다.
+            _floor = scene.name == "MainScene" ? 0 : _history.Count;
+            RefreshVisibility();
         }
 
         // 씬 전환 후 @UI_Root의 Canvas worldCamera를 새 씬의 Camera.main으로 갱신
@@ -57,18 +76,16 @@ namespace SCOdyssey.App
             }
         }
 
-        private void SetCanvas(GameObject go, bool sort = true)
+        // Canvas 1회 구성 (sortingOrder는 RefreshVisibility가 표시 깊이에 따라 매번 재할당)
+        private void ConfigureCanvas(GameObject go)
         {
             Canvas canvas = go.GetComponent<Canvas>();
 
             // Screen Space - Camera: Camera.rect(레터박스)를 Canvas에도 적용
-            canvas.renderMode    = RenderMode.ScreenSpaceCamera;
-            canvas.worldCamera   = Camera.main;
-            canvas.planeDistance = 10f;
+            canvas.renderMode      = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera     = Camera.main;
+            canvas.planeDistance   = 10f;
             canvas.overrideSorting = true;
-
-            if (sort) { canvas.sortingOrder = order++; }
-            else      { canvas.sortingOrder = 0; }
 
             // CanvasScaler 보장 (16:9 기준, Scale With Screen Size)
             var scaler = go.GetOrAddComponent<CanvasScaler>();
@@ -78,89 +95,105 @@ namespace SCOdyssey.App
             scaler.matchWidthOrHeight  = 0.5f;
         }
 
-        // UI 동적 생성
-        public T ShowUI<T>(string name = null, Transform parent = null) where T : BaseUI
+        private BaseUI GetUI(string key)
         {
-            T peekUI = PeekUI<T>();
-            if (peekUI != null)
+            // 레지스트리에 캐시된 UI가 있으면 그대로 반환
+            if (_instances.TryGetValue(key, out var cached) && cached != null)
             {
-                return peekUI; // 이미 활성화된 UI가 있으면 그것을 반환
+                return cached;
             }
 
-            // 이름이 없다면 타입을 이름으로 사용
-            if (string.IsNullOrEmpty(name))
-            {
-                name = typeof(T).Name;
-            }
-            // UI 생성 후 스택에 넣기
-            GameObject go = ResourceLoader.PrefabInstantiate($"UI/{name}");
-            T ui = go.GetComponent<T>();
-            uiStack.Push(ui);
-            SetCanvas(go);
+            // 캐시가 없으면 동적 생성 후 캐싱
+            GameObject go = ResourceLoader.PrefabInstantiate($"UI/{key}");
+            go.transform.SetParent(Root.transform);
+            ConfigureCanvas(go);
 
-            // 부모 설정
-            if (parent != null)
-            {
-                go.transform.SetParent(parent);
-            }
-            else
-            {
-                // parameter가 없다면 @UI_Root를 부모로 설정
-                go.transform.SetParent(Root.transform);
-            }
+            BaseUI ui = go.GetComponent<BaseUI>();
+            _instances[key] = ui;
             return ui;
         }
 
-        // UI 스택에서 T타입의 UI를 return
-        private T FindUI<T>() where T : BaseUI
+        // UI 동적 표시
+        public T ShowUI<T>(PushMode mode = PushMode.Push) where T : BaseUI
         {
-            foreach (var item in uiStack)
+            string key = typeof(T).Name;
+
+            // 이미 최상단인 UI를 다시 요청하면 그대로 반환 (중복 push 방지)
+            if (_history.Count > 0 && _history.Peek().key == key)
             {
-                if (item is T)
-                {
-                    return item as T;
-                }
+                return (T)GetUI(key);
             }
-            return null;
+
+            BaseUI ui = GetUI(key);
+
+            // Replace: 현재 최상단 기록을 같은 Depth로 교체
+            if (mode == PushMode.Replace && _history.Count > 0)
+            {
+                _history.Pop();
+            }
+            _history.Push(new Entry(key, mode));
+
+            RefreshVisibility();
+            return (T)ui;
         }
 
-        // UI스택의 가장 위에 있는 UI return
-        private T PeekUI<T>() where T : BaseUI
+        // 입력 라우팅용: 현재 최상단 UI 반환 (없으면 null)
+        // 최당산의 UI만 입력을 받도록 PeekUI()를 통해 라우팅한다. (UIManager는 입력 이벤트를 직접 처리하지 않음)
+        public BaseUI PeekUI()
         {
-            // 스택이 비어있으면 null return
-            if (uiStack.Count == 0)
-            {
-                return null;
-            }
-            // 스택의 가장 위 UI와 T의 타입이 맞지 않으면 null return
-            return uiStack.Peek() as T;
+            if (_history.Count == 0) return null;
+            return _instances.TryGetValue(_history.Peek().key, out var ui) ? ui : null;
         }
-        
-        // UI 스택의 가장 위에 있는 UI 닫기
+
+        // UI 스택의 가장 위에 있는 UI 닫기 (캐시는 유지, Destroy 하지 않음)
         public void CloseUI(BaseUI closeUi)
         {
-            // 스택이 비어있으면 return
-            if (uiStack.Count == 0)
+            if (_history.Count == 0)
             {
                 return;
             }
-            // 가장 위에 있는 UI가 닫으려는 UI와 다르다면 Fail로그 출력 후 return
-            if (uiStack.Peek() != closeUi)
+            if (PeekUI() != closeUi)
             {
                 Debug.Log("Close ui Failed!");
                 return;
             }
 
-            // UI 스택에서 Pop & Destroy
-            BaseUI destroyUi = uiStack.Pop();
-            Object.Destroy(destroyUi.gameObject);
+            _history.Pop();
+            RefreshVisibility();
+        }
 
-            Canvas canvas = closeUi.GetComponent<Canvas>();
+        // 표시 집합 계산 → 활성/비활성 토글 + sortingOrder 재할당을 위해 구분한다.
+        // 표시 집합 구분 = 최상단부터 아래로, Overlay인 동안 그 아래까지 포함하고,
+        //                 Overlay가 아닌 첫 UI를 포함한 뒤 정지. 단, 바닥경계(_floor) 밑으로는 내려가지 않음.
+        private void RefreshVisibility()
+        {
+            Entry[] arr = _history.ToArray();           // arr[0] = 최상단
+            int aboveFloor = arr.Length - _floor;       // 바닥경계 위(현재 씬 소유) 기록 수
 
-            // SetCanvas가 된 UI를 닫을 때는 order 되돌리기
-            if (canvas.sortingOrder < 0)
+            var visible = new List<BaseUI>();           // 0번이 최상단
+            for (int i = 0; i < arr.Length && i < aboveFloor; i++)
             {
-                order--;
+                visible.Add(GetUI(arr[i].key));
+                if (arr[i].mode != PushMode.Overlay) break; // base 도달 ㅅㅣ 정지
+            }
+
+            // 표시 집합 외의 모든 캐시는 비활성화
+            var visibleSet = new HashSet<BaseUI>(visible);
+            foreach (var ui in _instances.Values)
+            {
+                if (ui == null) continue;
+                if (!visibleSet.Contains(ui) && ui.gameObject.activeSelf)
+                    ui.gameObject.SetActive(false);
+            }
+
+            // 표시 집합 활성화 + sortingOrder 재할당 (아래일수록 낮게, 최상단이 가장 높게)
+            for (int i = 0; i < visible.Count; i++)
+            {
+                BaseUI ui = visible[i];
+                if (ui.TryGetComponent<Canvas>(out var canvas))
+                    canvas.sortingOrder = BaseSortingOrder + (visible.Count - 1 - i);
+                if (!ui.gameObject.activeSelf)
+                    ui.gameObject.SetActive(true);
             }
         }
     }

--- a/Assets/Scripts/App/UIStack.cs
+++ b/Assets/Scripts/App/UIStack.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace SCOdyssey.App
+{
+    // UI 네비게이션의 순수 로직만 담는 자료구조로 분리(UnityEngine 의존 없음).
+    // 인스턴스 소유/생성/활성화/Canvas 등 Unity 관련은 UIManager가 담당한다
+    public sealed class UIStack
+    {
+        private readonly struct Entry
+        {
+            public readonly string key;
+            public readonly PushMode mode;
+            public Entry(string key, PushMode mode) { this.key = key; this.mode = mode; }
+        }
+
+        // _history : 기록만 보관 (UI 키 + 진입 모드). 뒤로가기 경로를 기억한다.
+        private readonly Stack<Entry> _history = new Stack<Entry>();
+
+        // 씬 바닥 경계: 이 Depth 하위의 UI는 현재 씬에서 표시하지 않는다.
+        private int _floor = 0;
+
+        public int Count => _history.Count;
+
+        // 현재 최상단 UI 키 (없으면 null)
+        public string TopKey => _history.Count == 0 ? null : _history.Peek().key;
+
+        // 새 UI 기록 추가. Replace면 현재 최상단을 같은 Depth로 교체한다
+        public void Push(string key, PushMode mode)
+        {
+            if (mode == PushMode.Replace && _history.Count > 0)
+            {
+                _history.Pop();
+            }
+            _history.Push(new Entry(key, mode));
+        }
+
+        // 최상단 기록 제거
+        public void Pop()
+        {
+            if (_history.Count > 0)
+            {
+                _history.Pop();
+            }
+        }
+
+        public void SetFloor(int floor)
+        {
+            _floor = floor;
+        }
+
+        // 표시할 UI 키 목록(최상단 우선)을 반환.
+        // 최상단부터 아래로, Overlay인 동안 그 아래까지 포함하고 Overlay가 아닌 첫 UI를 포함한 뒤 정지.
+        // 단, 바닥 경계(_floor) 밑으로는 내려가지 않는다.
+        public IReadOnlyList<string> GetVisibleKeys()
+        {
+            Entry[] arr = _history.ToArray();       // arr[0] = 최상단
+            int aboveFloor = arr.Length - _floor;   // 바닥 경계 위(현재 씬 소유) 기록 수
+
+            var keys = new List<string>();
+            for (int i = 0; i < arr.Length && i < aboveFloor; i++)
+            {
+                keys.Add(arr[i].key);
+                if (arr[i].mode != PushMode.Overlay) break; // base 도달 시 정지
+            }
+            return keys;
+        }
+    }
+}

--- a/Assets/Scripts/App/UIStack.cs.meta
+++ b/Assets/Scripts/App/UIStack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d0b6746ac65c94488d87562e93758de

--- a/Assets/Scripts/UI/BaseUI.cs
+++ b/Assets/Scripts/UI/BaseUI.cs
@@ -31,9 +31,9 @@ namespace SCOdyssey.UI
             {
                 inputManager.SwitchToUI();
 
-                inputManager.OnSelect += HandleSelect;
-                inputManager.OnSubmit += HandleSubmit;
-                inputManager.OnCancel += HandleCancel;
+                inputManager.OnSelect += OnSelectInternal;
+                inputManager.OnSubmit += OnSubmitInternal;
+                inputManager.OnCancel += OnCancelInternal;
             }
         }
 
@@ -41,10 +41,20 @@ namespace SCOdyssey.UI
         {
             if (inputManager != null)
             {
-                inputManager.OnSelect -= HandleSelect;
-                inputManager.OnSubmit -= HandleSubmit;
-                inputManager.OnCancel -= HandleCancel;
+                inputManager.OnSelect -= OnSelectInternal;
+                inputManager.OnSubmit -= OnSubmitInternal;
+                inputManager.OnCancel -= OnCancelInternal;
             }
+        }
+
+        // 스택 top UI에만 입력을 라우팅 — 아래(또는 오버레이 하단) UI들이 같은 키를 동시에 처리하지 않도록 함
+        private void OnSelectInternal(Vector2 d) { if (IsTopUI()) HandleSelect(d); }
+        private void OnSubmitInternal()          { if (IsTopUI()) HandleSubmit(); }
+        private void OnCancelInternal()          { if (IsTopUI()) HandleCancel(); }
+
+        private bool IsTopUI()
+        {
+            return ServiceLocator.TryGet(out IUIManager m) && m.PeekUI() == this;
         }
 
         protected abstract void HandleSelect(Vector2 direction);


### PR DESCRIPTION
## 개요
UIManager가 `Stack<BaseUI>` 하나로 **UI 레지스트리 기록 / UI 인스턴스 생명주기 / Z-order**를 모두 떠안던 구조를, **기록과 인스턴스 소유를 분리**한 구조로 재설계합니다.


## 해결해야 할 사항
- **복귀 신호 없음** — `CloseUI`가 위 UI를 `Destroy`만 하고 끝나, 아래에 깔린 UI(예: MainUI)는 "내가 다시 최상단이 됐다"는 신호를 못 받음 → 로비 복귀 시 후처리(BGM 등)를 걸 곳이 없었음.
- **입력 다중 처리** — push 시 아래 UI를 비활성화하지 않아, 활성 UI들이 같은 키 입력을 동시에 처리.


## 설계 시 고려 사항
- 키 기반 기록 분리로, "어느 UI로 돌아갈지"는 인스턴스 캐시/Destroy 정책과 무관하게 `_history`가 보존.
- `PushMode`는 이번 PR에서 **정의만** 되며 기본값이 `Push`라 기존 동작과 동일. 모드 채택은 후속 PR.


## 변경 사항
- **`IUIManager`**
  - `enum PushMode { Push, Overlay, Replace }` 추가
  - `ShowUI<T>(PushMode mode = PushMode.Push)` / `PeekUI()` 시그니처 정리 (미사용 `name`/`parent` 제거)
- **`UIManager`**
  - `Stack<BaseUI>` → `Stack<Entry>`(기록: 키 + 모드) + `Dictionary<string,BaseUI>`(인스턴스 소유, 캐싱)
  - `CloseUI` 시 Destroy 대신 캐싱 후 재사용
  - `RefreshVisibility()`로 표시 집합·sortingOrder 일괄 계산, 씬 바닥경계(`_floor`)로 게임 씬에서 로비 UI가 표시되지 않도록 처리
- **`BaseUI`**
  - 입력을 최상단 UI에만 라우팅(`PeekUI()` + `IsTopUI()`)
  - 진입/탈출 생명주기를 `OnEnable`/`OnDisable`로 통일



close #44